### PR TITLE
0.8.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "node-service"
-version = "0.8.4"
+version = "0.8.5"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "node_service", from = "src"}]

--- a/src/node_service/__init__.py
+++ b/src/node_service/__init__.py
@@ -115,11 +115,13 @@ async def shutdown_if_idle_for_too_long():
     """WARNING: Errors/stdout from this function are completely hidden!"""
 
     # this is in a for loop so the wait time can be extended while waiting
-    for _ in range(SELF["current_time_until_shutdown"]):
+    while SELF["current_time_until_shutdown"] > 1:
         await asyncio.sleep(1)
 
     if not IN_DEV:
-        struct = dict(message=f"SHUTTING DOWN NODE DUE TO INACTIVITY: {INSTANCE_NAME}")
+        msg = f'time remaining: {SELF["current_time_until_shutdown"]}'
+        msg += f"SHUTTING DOWN NODE DUE TO INACTIVITY: {INSTANCE_NAME}"
+        struct = dict(message=msg)
         GCL_CLIENT.log_struct(struct, severity="WARNING")
 
         instance_client = InstancesClient()

--- a/src/node_service/endpoints.py
+++ b/src/node_service/endpoints.py
@@ -25,7 +25,7 @@ from node_service import (
     get_add_background_task_function,
     Container,
 )
-from node_service.helpers import Logger, format_traceback, list_all_local_containers
+from node_service.helpers import Logger, format_traceback
 from node_service.worker import Worker
 from node_service import ACCESS_TOKEN
 
@@ -189,7 +189,7 @@ def reboot_containers(
         if new_container_config:
             SELF["current_container_config"] = new_container_config
 
-        docker_client = docker.DockerClient(base_url="unix://var/run/docker.sock")
+        docker_client = docker.APIClient(base_url="unix://var/run/docker.sock")
         node_doc = firestore.Client(project=PROJECT_ID).collection("nodes").document(INSTANCE_NAME)
         node_doc.update(
             {
@@ -202,13 +202,14 @@ def reboot_containers(
         )
 
         # remove all containers (except those named `main_service`)
-        for container in list_all_local_containers(docker_client):
-            try:
-                container.remove(force=True)
-            except (APIError, NotFound, requests.exceptions.HTTPError) as e:
-                # re-raise any errors that aren't an "already-in-progress" error
-                if not (("409" in str(e)) or ("404" in str(e))):
-                    raise e
+        for container in docker_client.containers():
+            if container["Names"][0] != "/main_service":
+                try:
+                    docker_client.remove_container(container["Id"], force=True)
+                except (APIError, NotFound, requests.exceptions.HTTPError) as e:
+                    # re-raise any errors that aren't an "already-in-progress" error
+                    if not (("409" in str(e)) or ("404" in str(e))):
+                        raise e
 
         def create_worker(*a, **kw):
             # Log error inside thread because sometimes it isn't sent to the main thread, idk why.
@@ -241,7 +242,8 @@ def reboot_containers(
 
         # Sometimes on larger machines, some containers don't start, or get stuck in "CREATED" state
         # This has not been diagnosed, this check is performed to ensure all containers started.
-        containers_status = [c.status for c in list_all_local_containers(docker_client)]
+        containers = [c for c in docker_client.containers() if c["Names"][0] != "/main_service"]
+        containers_status = [c["State"] for c in containers]
         num_running_containers = sum([status == "running" for status in containers_status])
         expected_n_containers = len(SELF["current_container_config"]) * INSTANCE_N_CPUS
         some_containers_missing = num_running_containers != expected_n_containers

--- a/src/node_service/endpoints.py
+++ b/src/node_service/endpoints.py
@@ -189,8 +189,7 @@ def reboot_containers(
         if new_container_config:
             SELF["current_container_config"] = new_container_config
 
-        # docker_client = docker.from_env(timeout=240)
-        docker_client = docker.APIClient(base_url="unix://var/run/docker.sock")
+        docker_client = docker.DockerClient(base_url="unix://var/run/docker.sock")
         node_doc = firestore.Client(project=PROJECT_ID).collection("nodes").document(INSTANCE_NAME)
         node_doc.update(
             {

--- a/src/node_service/endpoints.py
+++ b/src/node_service/endpoints.py
@@ -189,7 +189,8 @@ def reboot_containers(
         if new_container_config:
             SELF["current_container_config"] = new_container_config
 
-        docker_client = docker.from_env(timeout=240)
+        # docker_client = docker.from_env(timeout=240)
+        docker_client = docker.APIClient(base_url="unix://var/run/docker.sock")
         node_doc = firestore.Client(project=PROJECT_ID).collection("nodes").document(INSTANCE_NAME)
         node_doc.update(
             {

--- a/src/node_service/endpoints.py
+++ b/src/node_service/endpoints.py
@@ -147,8 +147,6 @@ def execute(
 
     assigned_starting_indicies = asyncio.run(assign_workers(workers_to_keep))
 
-    print(f"Assigned starting indicies: {assigned_starting_indicies}")
-
     if not len(assigned_starting_indicies) == len(workers_to_keep):
         desired_starting_indicies = list(range(starting_index, len(workers_to_keep)))
         unassigned_indicies = set(desired_starting_indicies) - set(assigned_starting_indicies)

--- a/src/node_service/helpers.py
+++ b/src/node_service/helpers.py
@@ -19,10 +19,6 @@ PRIVATE_PORT_QUEUE = deque(range(32768, 60999))  # <- these ports should be most
 
 
 def list_all_local_containers(docker_client: DockerClient):
-
-    # switch from api client to higher level client
-    docker_client = docker.DockerClient(client=docker_client)
-
     # for some reason `docker_client.containers.list(all=True)` likes to frequently not work
     for attempt in range(10):
         try:

--- a/src/node_service/helpers.py
+++ b/src/node_service/helpers.py
@@ -1,37 +1,16 @@
 import sys
 import socket
-import requests
-from time import sleep
 from itertools import groupby
 from typing import Optional
 from datetime import datetime, timedelta, timezone
 
 from collections import deque
-import docker
-from docker import DockerClient
-from docker.errors import APIError, NotFound
 
 from fastapi import Request
 from node_service import IN_DEV, GCL_CLIENT, SELF
 
 
 PRIVATE_PORT_QUEUE = deque(range(32768, 60999))  # <- these ports should be mostly free.
-
-
-def list_all_local_containers(docker_client: DockerClient):
-    # for some reason `docker_client.containers.list(all=True)` likes to frequently not work
-    for attempt in range(10):
-        try:
-            current_containers = docker_client.containers.list(all=True)
-            break
-        except (APIError, NotFound, requests.exceptions.HTTPError) as e:
-            sleep(1)
-            if attempt == 10:
-                raise e
-
-    # ignore `main_service` container so that I can run both the `main_service` and
-    # `node_service` locally at the same time during testing.
-    return [c for c in current_containers if c.name != "main_service"]
 
 
 def startup_error_msg(container_logs, image):

--- a/src/node_service/helpers.py
+++ b/src/node_service/helpers.py
@@ -7,6 +7,7 @@ from typing import Optional
 from datetime import datetime, timedelta, timezone
 
 from collections import deque
+import docker
 from docker import DockerClient
 from docker.errors import APIError, NotFound
 
@@ -18,6 +19,10 @@ PRIVATE_PORT_QUEUE = deque(range(32768, 60999))  # <- these ports should be most
 
 
 def list_all_local_containers(docker_client: DockerClient):
+
+    # switch from api client to higher level client
+    docker_client = docker.DockerClient(client=docker_client)
+
     # for some reason `docker_client.containers.list(all=True)` likes to frequently not work
     for attempt in range(10):
         try:

--- a/src/node_service/worker.py
+++ b/src/node_service/worker.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 from time import sleep
 
 import docker
+from docker import DockerClient
 from google.cloud import logging
 
 from node_service import PROJECT_ID, IN_DEV, ACCESS_TOKEN
@@ -33,16 +34,15 @@ class Worker:
         python_version: str,
         python_executable: str,
         image: str,
-        docker_client: docker.APIClient,
+        docker_client: DockerClient,
     ):
         self.container = None
         attempt = 0
-        auth_config = {"username": "oauth2accesstoken", "password": ACCESS_TOKEN}
-        # this fails using the higher level client for some reason
-        docker_client.pull(image, auth_config=auth_config)
 
-        # switch from api client to higher level client
-        docker_client = docker.DockerClient(client=docker_client)
+        # this fails using the higher level `DockerClient` for some reason
+        docker_api_client = docker.APIClient(base_url="unix://var/run/docker.sock")
+        auth_config = {"username": "oauth2accesstoken", "password": ACCESS_TOKEN}
+        docker_api_client.pull(image, auth_config=auth_config)
 
         while self.container is None:
             port = next_free_port()

--- a/src/node_service/worker.py
+++ b/src/node_service/worker.py
@@ -42,13 +42,13 @@ class Worker:
         auth_config = {"username": "oauth2accesstoken", "password": ACCESS_TOKEN}
         docker_client.pull(image, auth_config=auth_config)
 
-        images = docker_client.images()
-        print("Available images:", [img["RepoTags"] for img in images])
-
+        # ODDLY, if `docker_client.pull` fails to pull the image, it will NOT throw an error...
+        # check here that the image was actually pulled and exists on disk,
         try:
             docker_client.inspect_image(image)
         except docker.errors.ImageNotFound:
-            raise Exception(f"Image {image} not found after pulling")
+            msg = f"Image {image} not found after pulling!\nDid vm run out of disk space?"
+            raise Exception(msg)
 
         while self.container is None:
             port = next_free_port()

--- a/src/node_service/worker.py
+++ b/src/node_service/worker.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 from time import sleep
 
 import docker
-from docker import DockerClient
 from google.cloud import logging
 
 from node_service import PROJECT_ID, IN_DEV, ACCESS_TOKEN
@@ -34,38 +33,40 @@ class Worker:
         python_version: str,
         python_executable: str,
         image: str,
-        docker_client: DockerClient,
+        docker_client: docker.APIClient,
     ):
         self.container = None
         attempt = 0
 
-        # this fails using the higher level `DockerClient` for some reason
-        docker_api_client = docker.APIClient(base_url="unix://var/run/docker.sock")
+        # Use the provided APIClient directly
         auth_config = {"username": "oauth2accesstoken", "password": ACCESS_TOKEN}
-        docker_api_client.pull(image, auth_config=auth_config)
+        docker_client.pull(image, auth_config=auth_config)
 
         while self.container is None:
             port = next_free_port()
             gunicorn_command = f"gunicorn -t 60 -b 0.0.0.0:{port} container_service:app"
             short_image_name = image.split("/")[-1].split(":")[0]
             try:
-                self.container = docker_client.containers.run(
+                container = docker_client.create_container(
                     name=f"{short_image_name}_{str(uuid4())[:8]}",
                     image=image,
                     command=["/bin/sh", "-c", f"{python_executable} -m {gunicorn_command}"],
-                    ports={port: port},
-                    volumes=DEVELOPMENT_VOLUMES if IN_DEV else {},
+                    ports=[port],
+                    host_config=docker_client.create_host_config(
+                        port_bindings={port: port}, binds=DEVELOPMENT_VOLUMES if IN_DEV else None
+                    ),
                     environment={
                         "GOOGLE_CLOUD_PROJECT": PROJECT_ID,
                         "PROJECT_ID": PROJECT_ID,
                         "IN_DEV": IN_DEV,
                     },
-                    detach=True,
                 )
+                docker_client.start(container=container.get("Id"))
+                self.container = container
             except docker.errors.APIError as e:
                 if ("address already in use" in str(e)) or ("port is already allocated" in str(e)):
                     # This leaves an extra container in the "Created" state.
-                    containers_status = [c.status for c in docker_client.containers.list(all=True)]
+                    containers_status = [c["State"] for c in docker_client.containers(all=True)]
                     LOGGER.log_struct(
                         {
                             "severity": "WARNING",
@@ -81,29 +82,29 @@ class Worker:
                 traceback_str = "".join(traceback_details)
                 msg = "error thrown on `docker run` after returning."
                 log = {"message": msg, "exception": str(e), "traceback": traceback_str}
-                LOGGER.log_struct(dict(severity="WARNING").update(log))
+                LOGGER.log_struct(dict(severity="WARNING", **log))
                 pass  # Thrown by containers.run long after it has already returned ??
             else:
                 # Sometimes the container doesn't start and also doesn't throw an error ??
                 # This is the case when calling containers.run() and container.start()
                 attempt = 0
                 sleep(1)
-                self.container.reload()
-                while self.container.status == "created":
-                    self.container.start()
+                container_info = docker_client.inspect_container(self.container.get("Id"))
+                while container_info["State"]["Status"] == "created":
+                    docker_client.start(container=self.container.get("Id"))
                     attempt += 1
                     if attempt == 10:
                         raise Exception("Unable to start node.")
                     sleep(1)
-                    self.container.reload()
+                    container_info = docker_client.inspect_container(self.container.get("Id"))
 
                 if attempt > 1:
                     LOGGER.log_struct(
                         {
                             "severity": "INFO",
                             "message": f"CONTAINER STARTED! after {attempt+1} attempt(s)",
-                            "state": self.container.status,
-                            "name": self.container.name,
+                            "state": container_info["State"]["Status"],
+                            "name": container_info["Name"],
                         }
                     )
             attempt += 1
@@ -119,20 +120,22 @@ class Worker:
 
     def exists(self):
         try:
-            self.container.reload()
+            self.docker_client.inspect_container(self.container.get("Id"))
             return True
         except docker.errors.NotFound:
             return False
 
     def logs(self):
         if self.exists():
-            return self.container.logs().decode("utf-8")
+            return self.docker_client.logs(self.container.get("Id")).decode("utf-8")
         raise Exception("This worker no longer exists.")
 
     def remove(self):
         if self.exists():
             try:
-                self.container.remove(force=True)  # The "force" arg kills it if it's not stopped
+                self.docker_client.remove_container(
+                    self.container.get("Id"), force=True
+                )  # The "force" arg kills it if it's not stopped
             except docker.errors.APIError as e:
                 if not "409 Client Error" in str(e):
                     raise e
@@ -140,7 +143,7 @@ class Worker:
     def log_debug_info(self):
         container_logs = self.logs() if self.exists() else "Unable to retrieve container logs."
         container_logs = f"\nERROR INSIDE CONTAINER:\n{container_logs}\n"
-        containers_info = [vars(c) for c in self.docker_client.containers.list(all=True)]
+        containers_info = self.docker_client.containers(all=True)
         containers_info = json.loads(json.dumps(containers_info, default=lambda thing: str(thing)))
         logger = logging.Client().logger("node_service")
         logger.log_struct(


### PR DESCRIPTION
**Supports Burla client release 0.8.5:**

- Increases max num of inputs RPM can take (~500 -> 5,000,000 - ish)
- Set limit on max size of all inputs combined to 84MB.

**Node Service specific changes:**

- Fixes auto-shutdown
- switches from `docker.DockerClient` to `docker.APIclient`